### PR TITLE
Fix reader conditional in compression.cljc for ClojureScript

### DIFF
--- a/src/garden/compression.cljc
+++ b/src/garden/compression.cljc
@@ -2,7 +2,7 @@
   "Stylesheet compression utilities."
   #?@(:bb
       ()
-      :default
+      :clj
       ((:import (java.io StringReader StringWriter)
                 (com.yahoo.platform.yui.compressor CssCompressor)))))
 


### PR DESCRIPTION
The reader conditional `:default` is passing for ClojureScript, causing it to try to import java libraries:

```
The required namespace "java.io.StringReader" is not available, it was required by "garden/compression.cljc".
```