### PR TITLE
Replace YUI Compressor with actively maintained fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Replace YUI Compressor with resources-optimizer-maven-plugin
+- Upgrade deprecated integer parsing
+
 ## Added
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ or call `s/css-selector` explicitly. You can still use some of the sugar in
 `garden.selector` that doesn't depend on `IFn`, e.g. `(s/attr= :type "button")`.
 
 CSS Compression in Garden is delegated to
-`com.yahoo.platform.yui.compressor.CssCompressor`. Since that class is not
+`org.primefaces.extensions.optimizerplugin.optimizer.CssCompressor`. Since that class is not
 compiled into bb, there's no way to leverage it. This means you have to keep
-`:pretty-print?` on (the default). Someone could create a pod for YUI compressor
-if they really wanted, but we don't recommend using it anyway. YUI compressor is
+`:pretty-print?` on (the default). Someone could create a pod for the compressor
+if they really wanted, but we don't recommend using it anyway. The original YUI compressor is
 an unmaintained tool that has not kept up with modern CSS developments, and
 we've seen it make a mess and cause breaking changes in your CSS.
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,8 @@
 {:paths ["src"],
  :deps
- {com.yahoo.platform.yui/yuicompressor {:mvn/version "2.4.8"}}
+ {org.primefaces.extensions/resources-optimizer-maven-plugin
+  {:mvn/version "2.7.5"
+   :exclusions  [com.google.javascript/closure-compiler com.google.guava/guava]}}
 
  :aliases
  {:dev

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
   </scm>
   <dependencies>
     <dependency>
-      <groupId>com.yahoo.platform.yui</groupId>
-      <artifactId>yuicompressor</artifactId>
-      <version>2.4.8</version>
+      <groupId>org.primefaces.extensions</groupId>
+      <artifactId>resources-optimizer-maven-plugin</artifactId>
+      <version>2.7.5</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -30,8 +30,7 @@
   {;; When set to `true` the compiled stylesheet will be "pretty
    ;; printed." This would be equivalent to setting
    ;; `{:ouput-style => :expanded}` in Sass. When set to `false`
-   ;; the compiled stylesheet will be compressed with the YUI
-   ;; compressor.
+   ;; the compiled stylesheet will be compressed with the CssCompressor.
    :pretty-print? true
    ;; A sequence of files to prepend to the output file.
    :preamble []

--- a/src/garden/compression.cljc
+++ b/src/garden/compression.cljc
@@ -4,13 +4,13 @@
       ()
       :clj
       ((:import (java.io StringReader StringWriter)
-                (com.yahoo.platform.yui.compressor CssCompressor)))))
+                (org.primefaces.extensions.optimizerplugin.optimizer CssCompressor)))))
 
 ;; ---------------------------------------------------------------------
 ;; Clojure
 
-;; Clojure stylesheet compression leverages the YUI Compressor as it
-;; provides a performant and excellent solution to CSS compression.
+;; Clojure stylesheet compression leverages the Resources Optimizer Maven Plugin
+;; as it provides a performant and excellent solution to CSS compression.
 
 #?(:bb
    (defn compress-stylesheet
@@ -20,23 +20,18 @@
       (throw (ex-info "Not implemented on babashka" {}))))
    :clj
    (defn compress-stylesheet
-     "Compress a stylesheet with the YUI CSSCompressor. Set
+     "Compress a stylesheet with the CSSCompressor. Set
   line-break-position to -1 for no line breaks, 0 for a line break
   after each rule, and n > 0 for a line break after at most n
   columns. Defaults to no -1"
      ([stylesheet]
       (compress-stylesheet stylesheet -1))
      ([^String stylesheet line-break-position]
-      ;; XXX: com.yahoo.platform.yui.compressor.CssCompressor#compress replaces "0%" with "0" everywhere
-      ;;      which might have worked in 2013 when YUI Compressor 2.4.8 was released, but not anymore in 2019.
-      (with-open [reader (-> stylesheet
-                             (.replaceAll "(^|[^0-9])0%" "$10__YUIHACK__%")
-                             (StringReader.))
+      (with-open [reader (StringReader. stylesheet)
                   writer (StringWriter.)]
         (doto (CssCompressor. reader)
           (.compress writer line-break-position))
-        (-> (str writer)
-            (.replaceAll "0__YUIHACK__%" "0%"))))))
+        (str writer)))))
 
 ;; ---------------------------------------------------------------------
 ;; ClojureScript

--- a/src/garden/selectors.cljc
+++ b/src/garden/selectors.cljc
@@ -1059,5 +1059,5 @@
         sv (string/replace (str a b c) #"^0*" "")]
     (if (empty? sv)
       0
-      #?(:clj (Integer. sv)
+      #?(:clj (Integer/parseInt sv)
          :cljs (js/parseInt sv)))))


### PR DESCRIPTION
This PR replaces the YUI Compressor (a dead project) with an actively maintained fork of it.

Garden currently depends on the [YUI Compressor](https://github.com/yui/yuicompressor) library for CSS compression. This project has been dead for about 6 years.

A fork of this project exists and is actively being maintained as [resource-optimizer-maven-plugin](https://github.com/primefaces-extensions/resources-optimizer-maven-plugin). My first attempt at using this resulted in some minor regression in CSS compression, but since it is actively maintained, those regressions were able to be fixed in a timely manner.

While this PR may introduce some regression around CSS compressions in the short-term, it will provide the ability to fix those regressions and a path forward for modern CSS compression.